### PR TITLE
add wasmTarget to rustDevShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,10 @@
             extraBuildInputs ? [],
           }: pkgs.mkShell {
             buildInputs = [
-              pkgs.rust-bin.stable.${rustVersion}.default
+              (pkgs.rust-bin.stable.${rustVersion}.default.override {
+                extensions = ["rust-src"];
+                targets = [ wasmTarget ];
+              })
               cargo2nix.defaultPackage.${system}
             ] ++ extraBuildInputs;
           };


### PR DESCRIPTION
even when we aren't building for Holochain, we'd like to test that wasm support works. this mainly comes up for `rep_lang`.